### PR TITLE
Fix "undefined offset" notice in case of PDOException

### DIFF
--- a/src/LinguaLeo/MySQL/Query.php
+++ b/src/LinguaLeo/MySQL/Query.php
@@ -330,7 +330,7 @@ class Query implements QueryInterface
      */
     private function hideQueryException(\PDOException $e, $force)
     {
-        list($generalError, $code, $message) = $e->errorInfo;
+        list($generalError, $code) = $e->errorInfo;
         switch ($code) {
             case 2006: // MySQL server has gone away
             case 2013: // Lost connection to MySQL server during query


### PR DESCRIPTION
Иногда errorInfo в PDOException содержит массив не из трех, а из двух элементов. При этом третий нам никогда не нужен, но если его нет, то в логи попадает notice, а не сам PDOException.